### PR TITLE
Feat horario limite

### DIFF
--- a/dojo_recife_api/participantes/serializers.py
+++ b/dojo_recife_api/participantes/serializers.py
@@ -4,10 +4,13 @@ from django.utils import timezone
 
 
 class ParticipanteSerializer(serializers.ModelSerializer):
+    # Validar horário limite para inscrição do evento
     def validate_evento(self, value):
-        if value.data_hora_limite < timezone.now():
-            raise serializers.ValidationError('Passou do horário de inscrição do evento')
+        limite_evento = value.data_hora_limite
+        datatime_atual = timezone.now()
 
+        if limite_evento < datatime_atual:
+            raise serializers.ValidationError('Passou do horário de inscrição do evento ' + datatime_atual.strftime('%m %d %y %H %M'))
         return value
 
     class Meta:

--- a/dojo_recife_api/participantes/serializers.py
+++ b/dojo_recife_api/participantes/serializers.py
@@ -1,8 +1,15 @@
 from rest_framework import serializers
 from .models import Participante
+from django.utils import timezone
 
 
 class ParticipanteSerializer(serializers.ModelSerializer):
+    def validate_evento(self, value):
+        if value.data_hora_limite < timezone.now():
+            raise serializers.ValidationError('Passou do horário de inscrição do evento')
+
+        return value
+
     class Meta:
         model = Participante
         fields = ("id", "nome", "email", "telefone", "documento", "evento")

--- a/dojo_recife_api/settings.py
+++ b/dojo_recife_api/settings.py
@@ -109,11 +109,11 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "America/Recife"
 
 USE_I18N = True
 
-USE_TZ = True
+USE_TZ = False
 
 
 # Static files (CSS, JavaScript, Images)

--- a/dojo_recife_api/settings.py
+++ b/dojo_recife_api/settings.py
@@ -114,7 +114,7 @@ TIME_ZONE = "America/Recife"
 
 USE_I18N = True
 
-USE_TZ = False
+USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)

--- a/dojo_recife_api/settings.py
+++ b/dojo_recife_api/settings.py
@@ -110,8 +110,6 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "America/Recife"
-
 USE_I18N = True
 
 USE_TZ = True

--- a/manage.py
+++ b/manage.py
@@ -3,6 +3,7 @@
 import os
 import sys
 
+TIME_ZONE = 'America/Recife'
 
 def main():
     """Run administrative tasks."""

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,6 @@
 import os
 import sys
 
-TIME_ZONE = 'America/Recife'
 
 def main():
     """Run administrative tasks."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 
 asgiref==3.6.0
 attrs==22.2.0
-backports.zoneinfo==0.2.1
+backports.zoneinfo==0.2.1;python_version<"3.9"
 dj-database-url==1.3.0
 Django==4.1.7
 django-rest-framework==0.1.0

--- a/tests/tests_participantes/test_serializers.py
+++ b/tests/tests_participantes/test_serializers.py
@@ -1,5 +1,6 @@
 import pytest
 from dojo_recife_api.participantes.serializers import ParticipanteSerializer
+from dojo_recife_api.eventos.models import Evento
 
 pytestmark = pytest.mark.django_db
 
@@ -42,3 +43,33 @@ def test_partial_update_participante_serializer(participante, evento):
 
     assert updated_participante.id == participante.id
     assert updated_participante.nome != old_name
+
+def test_signup_past_limittime(evento):
+    participante_data = {
+        "nome": "Teste Depois Limite",
+        "email": "teste@email.com",
+        "telefone": "81900000000",
+        "documento": "00000000000",
+        "evento": evento.id
+    }
+
+    serializer = ParticipanteSerializer(data=participante_data)
+
+    assert not serializer.is_valid()
+
+
+def test_signup_before_limittime():
+    evento = Evento.objects.create(local="Vasco da Gama", data="2023-12-12", hora="19:00:00", max_pessoas=10, data_hora_limite="2023-12-10 10:00")
+
+    participante_data = {
+        "nome": "Teste Antes Limite",
+        "email": "testando@email.com",
+        "telefone": "81911111111",
+        "documento": "11111111111",
+        "evento": evento.id
+    }
+    
+    serializer = ParticipanteSerializer(data=participante_data)
+
+    assert serializer.is_valid()
+


### PR DESCRIPTION
Lança erro de validação quando a data e horário limite de inscrição para o evento é menor que a data e horário atual.

Tive que mudar o parametro USE_TZ pra false, se não a aplicação ia ignorar a timezone escolhida e usar UTC sempre.